### PR TITLE
[FEATURE]: Add getInitialProps function and (fix) use TM_FILENAME_BASE instead of TM_FILENAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.1.0 (2022-02-10)
+# 0.2.0 (2022-02-11)
 
 
 ### Features
 
-* add nextjs snippet ([8bd2027](https://github.com/avneesh0612/React-Next.js-snippets/commit/8bd2027d3a8fc5d30ea926319f263f029463139d))
-* added next js typescript component ([7da5468](https://github.com/avneesh0612/React-Next.js-snippets/commit/7da54689a5ab29ac27d9cf7c5dbf48e3e7f80ed8))
+* add nextjs snippet ([8bd2027](https://github.com/crebro/React-Next.js-snippets/commit/8bd2027d3a8fc5d30ea926319f263f029463139d))
+* added next js typescript component ([7da5468](https://github.com/crebro/React-Next.js-snippets/commit/7da54689a5ab29ac27d9cf7c5dbf48e3e7f80ed8))
 
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nextreactsnippets",
   "displayName": "Next.js and React Snippets",
   "description": "This is an extension for Next.js and React Snippets with ts support as well!",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.64.0"
   },

--- a/snippets/next-typescript.code-snippets
+++ b/snippets/next-typescript.code-snippets
@@ -28,16 +28,28 @@
     "body": [
       "import type { NextPage } from \"next\";",
       "",
-      "const ${1:${TM_FILENAME}}: NextPage = () => {",
+      "const ${1:${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}}: NextPage = () => {",
       "  return (",
       "    <>",
       "    </>",
       "  )",
       "}",
       "",
-      "export default ${1:${TM_FILENAME}}"
+      "export default ${1:${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}}"
     ],
     "description": "NextPage component with NextPage type"
+   },
+   "nextgip": {
+    "prefix": "nextgip",
+    "body": [
+      "${1:${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}}.getInitialProps = async context => {",
+      "  return {",
+      "    ",
+      "  };",
+      "};",
+      ""     
+    ],
+    "description": "Get Initial Props in Next.js"
    },
    "nct": {
 		"prefix": "nextct",

--- a/snippets/react-javascript.code-snippets
+++ b/snippets/react-javascript.code-snippets
@@ -2,11 +2,11 @@
   "rafce": {
     "prefix": "rafce",
     "body": [
-      "const ${1:${TM_FILENAME}}= () => {",
+      "const ${1:${TM_FILENAME_BASE}}= () => {",
       "  return <div></div>;",
       "};",
       "",
-      "export default ${1:${TM_FILENAME}};",
+      "export default ${1:${TM_FILENAME_BASE}};",
       ""
     ],
     "description": "React Functional Component"

--- a/snippets/react-typescript.code-snippets
+++ b/snippets/react-typescript.code-snippets
@@ -6,10 +6,10 @@
       "",
       "interface Props {}",
       "",
-      "const ${1:${TM_FILENAME}}: FC<Props> = () => {",
+      "const ${1:${TM_FILENAME_BASE}}: FC<Props> = () => {",
       "  return <div></div>;",
       "};",
-      "export default ${1:${TM_FILENAME}};"
+      "export default ${1:${TM_FILENAME_BASE}};"
     ],
     "description": "React Functional Component with Types"
   }


### PR DESCRIPTION

## Changes proposed
- Added snippet for getInitialProps function in next.js typescript
- Using TM_FILENAME_BASE instead of TM_FILENAME with gives the base of the filename, get ( Component ) and not ( Component.js or Component.jsx )

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed. ( Not tests available :P )
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
